### PR TITLE
minor typos + adds __typename to the seller

### DIFF
--- a/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
+++ b/src/Apps/Order/Components/__stories__/ShippingAndPaymentDetails.story.tsx
@@ -16,7 +16,7 @@ const order: ShippingAndPaymentReview_order &
     addressLine1: "23 41st st",
     addressLine2: null,
     city: "New York",
-    pPostalCode: "90210",
+    postalCode: "90210",
     region: "US",
   },
   lineItems: {

--- a/src/Apps/__test__/Fixtures/Order.ts
+++ b/src/Apps/__test__/Fixtures/Order.ts
@@ -36,6 +36,7 @@ export const UntouchedOrder = {
     ],
   },
   seller: {
+    __typename: "Partner",
     name: "Kathryn Markel Fine Arts",
     locations: [
       {

--- a/src/Artsy/Router/Components/StorybooksRouter.tsx
+++ b/src/Artsy/Router/Components/StorybooksRouter.tsx
@@ -53,7 +53,7 @@ export class StorybooksRouter extends React.Component<Props> {
         ClientApp,
       })
     } catch (error) {
-      console.error("ArtistApp.story", error)
+      console.error("StorybooksRouter.story", error)
     }
   }
 


### PR DESCRIPTION
@ashfurrow went down a huge rabbit hole with this.

There are two typo fixes, but the issue that was preventing the storybook from loading was the missing `__typename` on the seller.

I struggled to efficiently debug this, but was able to narrow it down to the `StorybookRouter` (the app actually worked fine for me when linked to my local force). Then I basically did some trial and error by diffing our fixture to the one in metaphysics: https://github.com/artsy/metaphysics/blob/master/src/test/fixtures/exchange/order.json 