### PR TITLE
Add conditional error messaging based on field *touched*

### DIFF
--- a/src/Apps/Order/Components/AddressForm.tsx
+++ b/src/Apps/Order/Components/AddressForm.tsx
@@ -16,6 +16,7 @@ export interface Address {
 }
 
 export type AddressErrors = Partial<Address>
+export type AddressTouched = Partial<{ [T in keyof Address]: boolean }>
 export type AddressChangeHandler = (
   address: Address,
   key: keyof Address
@@ -36,7 +37,8 @@ export interface AddressFormProps {
   defaultValue?: Partial<Address>
   billing?: boolean
   continentalUsOnly?: boolean
-  errors?: AddressErrors
+  errors: AddressErrors
+  touched: AddressTouched
 }
 
 interface AddressFormState {
@@ -70,6 +72,16 @@ export class AddressForm extends React.Component<
     })
   }
 
+  getError = (key: keyof Address): string => {
+    return (
+      (this.props.touched &&
+        this.props.touched[key] &&
+        this.props.errors &&
+        this.props.errors[key]) ||
+      ""
+    )
+  }
+
   render() {
     const lockCountryToUS = !this.props.billing && this.props.continentalUsOnly
     return (
@@ -83,7 +95,7 @@ export class AddressForm extends React.Component<
             autoCorrect="off"
             defaultValue={this.props.defaultValue.name}
             onChange={this.changeEventHandler("name")}
-            error={this.props.errors && this.props.errors.name}
+            error={this.getError("name")}
             block
           />
         </Flex>
@@ -117,7 +129,7 @@ export class AddressForm extends React.Component<
               autoCorrect="off"
               defaultValue={this.props.defaultValue.postalCode}
               onChange={this.changeEventHandler("postalCode")}
-              error={this.props.errors && this.props.errors.postalCode}
+              error={this.getError("postalCode")}
               block
             />
           </Flex>
@@ -131,7 +143,7 @@ export class AddressForm extends React.Component<
               autoCapitalize="words"
               defaultValue={this.props.defaultValue.addressLine1}
               onChange={this.changeEventHandler("addressLine1")}
-              error={this.props.errors && this.props.errors.addressLine1}
+              error={this.getError("addressLine1")}
               block
             />
           </Flex>
@@ -144,6 +156,7 @@ export class AddressForm extends React.Component<
               autoCapitalize="words"
               defaultValue={this.props.defaultValue.addressLine2}
               onChange={this.changeEventHandler("addressLine2")}
+              error={this.getError("addressLine2")}
               block
             />
           </Flex>
@@ -157,7 +170,7 @@ export class AddressForm extends React.Component<
               autoCapitalize="words"
               defaultValue={this.props.defaultValue.city}
               onChange={this.changeEventHandler("city")}
-              error={this.props.errors && this.props.errors.city}
+              error={this.getError("city")}
               block
             />
           </Flex>
@@ -170,7 +183,7 @@ export class AddressForm extends React.Component<
               autoCorrect="off"
               defaultValue={this.props.defaultValue.region}
               onChange={this.changeEventHandler("region")}
-              error={this.props.errors && this.props.errors.region}
+              error={this.getError("region")}
               block
             />
           </Flex>
@@ -186,7 +199,7 @@ export class AddressForm extends React.Component<
                 pattern="[0-9]*"
                 defaultValue={this.props.defaultValue.phoneNumber}
                 onChange={this.changeEventHandler("phoneNumber")}
-                error={this.props.errors && this.props.errors.phoneNumber}
+                error={this.getError("phoneNumber")}
                 block
               />
             </Flex>

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -9,6 +9,7 @@ import {
   AddressChangeHandler,
   AddressErrors,
   AddressForm,
+  AddressTouched,
   emptyAddress,
 } from "../../Components/AddressForm"
 
@@ -47,6 +48,7 @@ interface PaymentState {
   hideBillingAddress: boolean
   address: Address
   addressErrors: AddressErrors
+  addressTouched: AddressTouched
   stripeError: stripe.Error
   isCommittingMutation: boolean
   isErrorModalOpen: boolean
@@ -62,6 +64,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
     errorModalMessage: null,
     address: this.startingAddress(),
     addressErrors: {},
+    addressTouched: {},
   }
 
   startingAddress(): Address {
@@ -86,12 +89,29 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
     }
   }
 
+  get touchedAddress() {
+    return {
+      name: true,
+      country: true,
+      postalCode: true,
+      addressLine1: true,
+      addressLine2: true,
+      city: true,
+      region: true,
+      phoneNumber: true,
+    }
+  }
+
   onContinue: () => void = () => {
     this.setState({ isCommittingMutation: true }, () => {
       if (this.needsAddress()) {
         const errors = this.validateAddress(this.state.address)
         if (Object.keys(errors).filter(key => errors[key]).length > 0) {
-          this.setState({ isCommittingMutation: false, addressErrors: errors })
+          this.setState({
+            isCommittingMutation: false,
+            addressErrors: errors,
+            addressTouched: this.touchedAddress,
+          })
           return
         }
       }
@@ -137,6 +157,10 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
         ...this.state.addressErrors,
         [key]: this.validateAddress(address)[key],
       },
+      addressTouched: {
+        ...this.state.addressTouched,
+        [key]: true,
+      },
     })
   }
 
@@ -151,6 +175,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
       isCommittingMutation,
       address,
       addressErrors,
+      addressTouched,
     } = this.state
 
     return (
@@ -204,6 +229,7 @@ export class PaymentRoute extends Component<PaymentProps, PaymentState> {
                         <AddressForm
                           defaultValue={address}
                           errors={addressErrors}
+                          touched={addressTouched}
                           onChange={this.onAddressChange}
                           billing
                         />

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -16,6 +16,7 @@ import {
   AddressChangeHandler,
   AddressErrors,
   AddressForm,
+  AddressTouched,
   emptyAddress,
 } from "Apps/Order/Components/AddressForm"
 import { BuyNowStepper } from "Apps/Order/Components/BuyNowStepper"
@@ -51,6 +52,7 @@ export interface ShippingState {
   shippingOption: OrderFulfillmentType
   address: Address
   addressErrors: AddressErrors
+  addressTouched: AddressTouched
   isCommittingMutation: boolean
   isErrorModalOpen: boolean
   errorModalTitle: string
@@ -66,6 +68,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
     isErrorModalOpen: false,
     address: this.startingAddress,
     addressErrors: {},
+    addressTouched: {},
     errorModalTitle: null,
     errorModalMessage: null,
   }
@@ -81,17 +84,37 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
     }
   }
 
+  get touchedAddress() {
+    return {
+      name: true,
+      country: true,
+      postalCode: true,
+      addressLine1: true,
+      addressLine2: true,
+      city: true,
+      region: true,
+      phoneNumber: true,
+    }
+  }
+
   onContinueButtonPressed: () => void = () => {
+    console.log("OCBP")
     this.setState({ isCommittingMutation: true }, () => {
+      console.log("1 - started")
       const { address, shippingOption } = this.state
 
       if (this.state.shippingOption === "SHIP") {
+        console.log("2 - ship selected")
         const errors = this.validateAddress(this.state.address)
-
-        if (Object.keys(errors).filter(key => errors[key]).length > 0) {
+        const thereAreErrors =
+          Object.keys(errors).filter(key => errors[key]).length > 0
+        console.log("3- are there errors?", thereAreErrors)
+        if (thereAreErrors) {
+          console.log("4 - touching everything...")
           this.setState({
             isCommittingMutation: false,
             addressErrors: errors,
+            addressTouched: this.touchedAddress,
           })
           return
         }
@@ -234,12 +257,21 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
         ...this.state.addressErrors,
         ...this.validateAddress(address),
       },
+      addressTouched: {
+        ...this.state.addressTouched,
+        [key]: true,
+      },
     })
   }
 
   render() {
     const { order } = this.props
-    const { address, addressErrors, isCommittingMutation } = this.state
+    const {
+      address,
+      addressErrors,
+      addressTouched,
+      isCommittingMutation,
+    } = this.state
     const artwork = get(
       this.props,
       props => order.lineItems.edges[0].node.artwork
@@ -307,6 +339,7 @@ export class ShippingRoute extends Component<ShippingProps, ShippingState> {
                       <AddressForm
                         defaultValue={address}
                         errors={addressErrors}
+                        touched={addressTouched}
                         onChange={this.onAddressChange}
                         continentalUsOnly={artwork.shipsToContinentalUSOnly}
                       />

--- a/src/Apps/Order/Routes/__tests__/Payment.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.test.tsx
@@ -375,10 +375,42 @@ describe("Payment", () => {
       ;(paymentRoute.find(Checkbox).props() as CheckboxProps).onSelect(false)
 
       paymentRoute.find(ContinueButton).simulate("click")
+      paymentRoute.update()
       const input = paymentRoute
         .find(Input)
         .filterWhere(wrapper => wrapper.props().title === "Full name")
       expect(input.props().error).toEqual("This field is required")
+    })
+    it("before submit, only shows a validation error on inputs that have been touched", () => {
+      const component = mount(<PaymentRoute {...testProps} />)
+      ;(component.find(Checkbox).props() as CheckboxProps).onSelect(false)
+
+      fillIn(component, { title: "Full name", value: "Erik David" })
+      fillIn(component, { title: "Address line 1", value: "" })
+      component.update()
+
+      const [addressInput, cityInput] = ["Address line 1", "City"].map(label =>
+        component
+          .find(Input)
+          .filterWhere(wrapper => wrapper.props().title === label)
+      )
+
+      expect(addressInput.props().error).toBeTruthy()
+      expect(cityInput.props().error).toBeFalsy()
+    })
+    it("after submit, shows all validation errors on inputs that have been touched", () => {
+      const component = mount(<PaymentRoute {...testProps} />)
+      ;(component.find(Checkbox).props() as CheckboxProps).onSelect(false)
+
+      fillIn(component, { title: "Full name", value: "Erik David" })
+
+      component.find("Button").simulate("click")
+
+      const cityInput = component
+        .find(Input)
+        .filterWhere(wrapper => wrapper.props().title === "City")
+
+      expect(cityInput.props().error).toBeTruthy()
     })
 
     it("does not submit an empty form with billing address exposed", () => {

--- a/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.test.tsx
@@ -337,6 +337,33 @@ describe("Shipping", () => {
 
       expect(commitMutation).toBeCalled()
     })
+    it("before submit, only shows a validation error on inputs that have been touched", () => {
+      const component = getWrapper(shipOrderProps)
+      fillIn(component, { title: "Full name", value: "Erik David" })
+      fillIn(component, { title: "Address line 1", value: "" })
+      component.update()
+
+      const [addressInput, cityInput] = ["Address line 1", "City"].map(label =>
+        component
+          .find(Input)
+          .filterWhere(wrapper => wrapper.props().title === label)
+      )
+
+      expect(addressInput.props().error).toBeTruthy()
+      expect(cityInput.props().error).toBeFalsy()
+    })
+    it("after submit, shows all validation errors on inputs that have been touched", () => {
+      const component = getWrapper(shipOrderProps)
+      fillIn(component, { title: "Full name", value: "Erik David" })
+
+      component.find("Button").simulate("click")
+
+      const cityInput = component
+        .find(Input)
+        .filterWhere(wrapper => wrapper.props().title === "City")
+
+      expect(cityInput.props().error).toBeTruthy()
+    })
     it("allows a missing state/province if the selected country is not US or Canada", () => {
       const component = getWrapper(shipOrderProps)
       const address = {

--- a/src/Apps/__stories__/OrderApp.story.tsx
+++ b/src/Apps/__stories__/OrderApp.story.tsx
@@ -2,6 +2,7 @@ import {
   mockResolver,
   OrderWithShippingDetails,
   PickupOrder,
+  UntouchedOrder,
 } from "Apps/__test__/Fixtures/Order"
 import { MockRouter } from "DevTools/MockRouter"
 import React from "react"
@@ -18,7 +19,15 @@ const Router = props => (
 )
 
 storiesOf("Apps/Order Page", module)
-  .add("Shipping", () => <Router initialRoute="/orders/123/shipping" />)
+  .add("Shipping - Pre-filled", () => (
+    <Router initialRoute="/orders/123/shipping" />
+  ))
+  .add("Shipping - Untouched Order", () => (
+    <Router
+      mockResolvers={mockResolver({ ...UntouchedOrder })}
+      initialRoute="/orders/123/shipping"
+    />
+  ))
   .add("Review", () => <Router initialRoute="/orders/123/review" />)
 
 storiesOf("Apps/Order Page/Status", module)


### PR DESCRIPTION
Quick first pass at adding some conditional error messaging to the postal code requirements.
There is also a new but broken (I think) story to show shipping form behavior starting from a blank order.